### PR TITLE
Add Pagination to Transactions Page

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -3,10 +3,12 @@ import Sidebar from '@/components/Sidebar';
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className='xl:flex'>
-      <div className='max-xl:fixed max-xl:bottom-0 max-xl:w-full flex flex-col xl:flex-row xl:h-screen'>
+      <div className='max-xl:fixed max-xl:bottom-0 max-xl:w-full flex flex-col xl:flex-row xl:min-h-screen'>
         <Sidebar />
       </div>
-      <main className='flex flex-col px-4 py-6 md:px-10 md:py-8 w-full'>{children}</main>
+      <main className='flex flex-col px-4 py-6 md:px-10 md:py-8 w-full max-xl:mb-20'>
+        {children}
+      </main>
     </div>
   );
 }

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -4,6 +4,14 @@ import { useState } from 'react';
 
 import Transaction from '@/components/Transaction';
 import Dropdown from '@/components/Dropdown';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
 import { transactions, dropdownSortLabels, dropdownCategories } from '../../../constants/data.json';
 
 const Transactions = () => {
@@ -11,10 +19,12 @@ const Transactions = () => {
   const [category, setCategory] = useState('All Transactions');
 
   const [search, setSearch] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const transactionsPerPage = 10;
 
   const getFilteredTransactions = () => {
     return transactions
-      .slice(0, 10)
       .filter((item) => item?.name.toLowerCase().includes(search))
       .filter(
         (transaction) =>
@@ -45,6 +55,14 @@ const Transactions = () => {
   };
 
   const filteredTransactions = getFilteredTransactions();
+
+  const startIndex = (currentPage - 1) * transactionsPerPage;
+  const endIndex = startIndex + transactionsPerPage;
+
+  const totalPages = Math.ceil(filteredTransactions.length / transactionsPerPage);
+  const pageNumbers = [...Array(totalPages).keys()].map((n) => n + 1);
+
+  const currentTransactions = filteredTransactions.slice(startIndex, endIndex);
 
   return (
     <div className='flex flex-col gap-8'>
@@ -91,10 +109,40 @@ const Transactions = () => {
           <h2 className='text-preset-5 text-gray-500 text-right'>Amount</h2>
         </div>
         <div>
-          {filteredTransactions.map((transaction, index) => (
+          {currentTransactions.map((transaction, index) => (
             <Transaction transaction={transaction} key={index} />
           ))}
         </div>
+        <Pagination>
+          <PaginationContent className='flex flex-row max-lg:justify-between select-none max-lg:w-full lg:gap-4'>
+            <PaginationItem>
+              <PaginationPrevious
+                onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+                className='border border-beige-500 rounded-[8px] text-preset-4 text-gray-900 hover:bg-beige-500 hover:text-white hover:cursor-pointer'
+              />
+            </PaginationItem>
+            <PaginationItem className='flex gap-2'>
+              {pageNumbers.map((page) => (
+                <PaginationLink
+                  key={page}
+                  onClick={() => setCurrentPage(page)}
+                  className={`rounded-[8px] text-preset-4 hover:bg-beige-500 hover:text-white hover:cursor-pointer ${
+                    page === currentPage
+                      ? 'bg-gray-900 text-white'
+                      : 'text-gray-900 border border-beige-500'
+                  }`}>
+                  {page}
+                </PaginationLink>
+              ))}
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationNext
+                onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPages))}
+                className='border border-beige-500 rounded-[8px] text-preset-4 text-gray-900 hover:bg-beige-500 hover:text-white hover:cursor-pointer'
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
       </div>
     </div>
   );

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Button, buttonVariants } from '@/components/ui/button';
+
+function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
+  return (
+    <nav
+      role='navigation'
+      aria-label='pagination'
+      data-slot='pagination'
+      className={cn('mx-auto flex w-full justify-center', className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationContent({ className, ...props }: React.ComponentProps<'ul'>) {
+  return (
+    <ul
+      data-slot='pagination-content'
+      className={cn('flex flex-row items-center gap-1', className)}
+      {...props}
+    />
+  );
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
+  return <li data-slot='pagination-item' {...props} />;
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean;
+} & Pick<React.ComponentProps<typeof Button>, 'size'> &
+  React.ComponentProps<'a'>;
+
+function PaginationLink({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? 'page' : undefined}
+      data-slot='pagination-link'
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? 'outline' : 'ghost',
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function PaginationPrevious({ className, ...props }: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label='Go to previous page'
+      size='default'
+      className={cn('gap-1 px-2.5 sm:pl-2.5', className)}
+      {...props}>
+      <ChevronLeftIcon />
+      <span className='hidden sm:block'>Prev</span>
+    </PaginationLink>
+  );
+}
+
+function PaginationNext({ className, ...props }: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label='Go to next page'
+      size='default'
+      className={cn('gap-1 px-2.5 sm:pr-2.5', className)}
+      {...props}>
+      <span className='hidden sm:block'>Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  );
+}
+
+function PaginationEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      aria-hidden
+      data-slot='pagination-ellipsis'
+      className={cn('flex size-9 items-center justify-center', className)}
+      {...props}>
+      <MoreHorizontalIcon className='size-4' />
+      <span className='sr-only'>More pages</span>
+    </span>
+  );
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.6",
+        "@radix-ui/react-slot": "^1.1.2",
         "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.6",
+    "@radix-ui/react-slot": "^1.1.2",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
### Summary

- Implemented pagination to Transactions page to divide the transactions dataset into smaller groups

### Features

- Ten transactions are displayed per page
- Prev/Next buttons and page numbers help navigate through the transactions
- Current page will be styled differently to signify the current/active page

### Next Steps

- Create Budgets page to display user's budgets